### PR TITLE
[invalid?] Limit number of players accepted to lobby

### DIFF
--- a/Patches/GameNetworkManager.cs
+++ b/Patches/GameNetworkManager.cs
@@ -25,7 +25,7 @@ internal static class ConnectionApproval_Patch
 		if (request.ClientNetworkId == NetworkManager.Singleton.LocalClientId)
 			return;
 
-		if (response.Reason.Contains("Game has already started") && GameNetworkManager.Instance.gameHasStarted) {
+		if (response.Reason.Contains("Game has already started") && GameNetworkManager.Instance.gameHasStarted && GameNetworkManager.Instance.connectedPlayers < 4) {
 			UnityEngine.Debug.Log("Uhh, no i do actually want this one to connect.");
 			response.Reason = "";
 			response.CreatePlayerObject = false;


### PR DESCRIPTION
A hotfix to prevent the lobby crashing when a 5th player tries to join the server. Will make this mod incompatible with Larger lobby mods.

Here's a possible change to this PR which **may** make the mod support more players, however I have not tested it
```c#
// attempt to add support for more members
int maxMembers = GameNetworkManager.Instance.currentLobby != null ? GameNetworkManager.Instance.currentLobby.Value.MaxMembers : 4;

if (response.Reason.Contains("Game has already started") && GameNetworkManager.Instance.gameHasStarted && GameNetworkManager.Instance.connectedPlayers < maxMembers) {
	UnityEngine.Debug.Log("Uhh, no i do actually want this one to connect.");
	response.Reason = "";
	response.CreatePlayerObject = false;
	response.Approved = true;
	response.Pending = false;
}
```