### PR TITLE
Weather Sync Fixes

### DIFF
--- a/Patches/RoundManager.cs
+++ b/Patches/RoundManager.cs
@@ -20,54 +20,47 @@ internal static class WeatherSync {
 
 [HarmonyPatch(typeof(RoundManager), "__rpc_handler_1193916134")]
 [HarmonyWrapSafe]
-internal static class __rpc_handler_1193916134_Patch
-{
-    public static FieldInfo RPCExecStage = typeof(NetworkBehaviour).GetField("__rpc_exec_stage", BindingFlags.NonPublic | BindingFlags.Instance);
+internal static class __rpc_handler_1193916134_Patch {
+	public static FieldInfo RPCExecStage = typeof(NetworkBehaviour).GetField("__rpc_exec_stage", BindingFlags.NonPublic | BindingFlags.Instance);
 
-    [HarmonyPrefix]
-    private static bool Prefix(NetworkBehaviour target, FastBufferReader reader, __RpcParams rpcParams)
-    {
-        NetworkManager networkManager = target.NetworkManager;
-        if (networkManager != null && networkManager.IsListening)
-        {
-            try
-            {
-                int randomSeed;
-                ByteUnpacker.ReadValueBitPacked(reader, out randomSeed);
-                int levelID;
-                ByteUnpacker.ReadValueBitPacked(reader, out levelID);
+	[HarmonyPrefix]
+	private static bool Prefix(NetworkBehaviour target, FastBufferReader reader, __RpcParams rpcParams) {
+		NetworkManager networkManager = target.NetworkManager;
+		if (networkManager != null && networkManager.IsListening) {
+			try {
+				int randomSeed;
+				ByteUnpacker.ReadValueBitPacked(reader, out randomSeed);
+				int levelID;
+				ByteUnpacker.ReadValueBitPacked(reader, out levelID);
 
-                int weatherId;
-                ByteUnpacker.ReadValueBitPacked(reader, out weatherId);
+				int weatherId;
+				ByteUnpacker.ReadValueBitPacked(reader, out weatherId);
 
-                WeatherSync.CurrentWeather = (LevelWeatherType)weatherId;
-                WeatherSync.DoOverride = true;
+				WeatherSync.CurrentWeather = (LevelWeatherType)weatherId;
+				WeatherSync.DoOverride = true;
 
-                RPCExecStage.SetValue(target, RpcEnum.Client);
-                (target as RoundManager).GenerateNewLevelClientRpc(randomSeed, levelID);
-                RPCExecStage.SetValue(target, RpcEnum.None);
-            }
-            catch
-            {
-                // Something went wrong, default to original method.
-                WeatherSync.DoOverride = false;
-                reader.Seek(0);
-                return true;
-            }
-        }
+				RPCExecStage.SetValue(target, RpcEnum.Client);
+				(target as RoundManager).GenerateNewLevelClientRpc(randomSeed, levelID);
+				RPCExecStage.SetValue(target, RpcEnum.None);
+			}
+			catch {
+				// Something went wrong, default to original method.
+				WeatherSync.DoOverride = false;
+				reader.Seek(0);
+				return true;
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 }
 
 [HarmonyPatch(typeof(RoundManager), "SetToCurrentLevelWeather")]
-internal static class SetToCurrentLevelWeather_Patch
-{
-    [HarmonyPrefix]
-    private static void Prefix()
-    {
-        if (!WeatherSync.DoOverride) return;
-        RoundManager.Instance.currentLevel.currentWeather = WeatherSync.CurrentWeather;
-        WeatherSync.DoOverride = false;
-    }
+internal static class SetToCurrentLevelWeather_Patch {
+	[HarmonyPrefix]
+	private static void Prefix() {
+		if (!WeatherSync.DoOverride) return;
+		RoundManager.Instance.currentLevel.currentWeather = WeatherSync.CurrentWeather;
+		WeatherSync.DoOverride = false;
+	}
 }


### PR DESCRIPTION
- Fixed `WeatherSync.DoOverride` possibly still being true if the `SetValue` or `GenerateNewLevelClientRpc` fail.
- Made `RoundManager.Instance.currentLevel.currentWeather` be set to the synced weather and allowed the original `RoundManager.SetToCurrentLevelWeather` function to run.