### PR TITLE
Fix state of Player Controller when someone leaves while dead.

### DIFF
--- a/Patches/StartOfRound.cs
+++ b/Patches/StartOfRound.cs
@@ -82,6 +82,7 @@ internal static class OnPlayerDC_Patch {
 		player.disableSyncInAnimation = false;
 		player.externalForceAutoFade = Vector3.zero;
 		player.freeRotationInInteractAnimation = false;
+		player.hasBeenCriticallyInjured = false;
 		player.health = 100;
 		player.helmetLight.enabled = false;
 		player.holdingWalkieTalkie = false;

--- a/Patches/StartOfRound.cs
+++ b/Patches/StartOfRound.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection.Emit;
 using UnityEngine;
 using System;
+using GameNetcodeStuff;
 
 namespace LateCompany.Patches;
 
@@ -63,9 +64,44 @@ internal static class OnPlayerConnectedClientRpc_Patch {
 [HarmonyWrapSafe]
 internal static class OnPlayerDC_Patch {
 	[HarmonyPostfix]
-	private static void Postfix() {
+	private static void Postfix(int playerObjectNumber) {
 		if (StartOfRound.Instance.inShipPhase)
 			Plugin.SetLobbyJoinable(true);
+
+		PlayerControllerB player = StartOfRound.Instance.allPlayerScripts[playerObjectNumber];
+		player.activatingItem = false;
+		player.bleedingHeavily = false;
+		player.clampLooking = false;
+		player.criticallyInjured = false;
+		player.Crouch(false);
+		player.disableInteract = false;
+		player.DisableJetpackControlsLocally();
+		player.disableLookInput = false;
+		player.disableMoveInput = false;
+		player.DisablePlayerModel(player.gameObject, enable: true, disableLocalArms: true);
+		player.disableSyncInAnimation = false;
+		player.externalForceAutoFade = Vector3.zero;
+		player.freeRotationInInteractAnimation = false;
+		player.health = 100;
+		player.helmetLight.enabled = false;
+		player.holdingWalkieTalkie = false;
+		player.inAnimationWithEnemy = null;
+		player.inShockingMinigame = false;
+		player.inSpecialInteractAnimation = false;
+		player.inVehicleAnimation = false;
+		player.isClimbingLadder = false;
+		player.isSinking = false;
+		player.isUnderwater = false;
+		player.mapRadarDotAnimator?.SetBool("dead", false);
+		player.playerBodyAnimator?.SetBool("Limp", false);
+		player.ResetZAndXRotation();
+		player.sinkingValue = 0f;
+		player.speakingToWalkieTalkie = false;
+		player.statusEffectAudio?.Stop();
+		player.thisController.enabled = true;
+		player.transform.SetParent(StartOfRound.Instance.playersContainer);
+		player.twoHanded = false;
+		player.voiceMuffledByEnemy = false;
 	}
 }
 


### PR DESCRIPTION
Fixes #44, Fixes #25

If players left the match after dying, `StartOfRound.ReviveDeadPlayers` would not be ran on the non-connected player slots. This resets the state to what the client would expect of a new player.

All clients need to reset the parent of disconnected players in case a player leaves while standing on the Cruiser. If the scene gets unloaded and a `PlayerController` is parented to a Cruiser that gets left behind, it will delete the Cruiser and the `PlayerController`.